### PR TITLE
`reserved` is a Map

### DIFF
--- a/hs-tree-sitter-generate-ast/app/TreeSitter/GenerateAst/Internal/Grammar.hs
+++ b/hs-tree-sitter-generate-ast/app/TreeSitter/GenerateAst/Internal/Grammar.hs
@@ -34,7 +34,7 @@ data Grammar = Grammar
   , rules :: !(Map RuleName Rule)
   , extras :: !(Vector Rule)
   , precedences :: !(Maybe (Vector (Vector PrecSpec)))
-  , reserved :: !(Maybe (Vector Rule))
+  , reserved :: !(Map RuleName Rule)
   , externals :: !(Maybe (Vector Rule))
   , inline :: !(Maybe (Vector RuleName))
   , conflicts :: !(Maybe (Vector (Vector RuleName)))


### PR DESCRIPTION
Some of my grammars outputs empty object here '^_^

from [1]:

> similar in structure to the main rules property, an object of
> reserved word sets associated with an array of reserved rules.

[1] https://tree-sitter.github.io/tree-sitter/creating-parsers/2-the-grammar-dsl.html