### PR TITLE
Explicitly named hidden rules

### DIFF
--- a/hs-tree-sitter-generate-ast/app/TreeSitter/GenerateAst/Internal/CodeGen.hs
+++ b/hs-tree-sitter-generate-ast/app/TreeSitter/GenerateAst/Internal/CodeGen.hs
@@ -28,7 +28,7 @@ import Data.Text.Lazy.Builder qualified as TLB
 import Text.DocLayout (Doc, render)
 import Text.DocLayout qualified as Doc (Doc (..))
 import Text.DocTemplates (Context (..), ToContext (..), Val (..), applyTemplate)
-import TreeSitter.GenerateAst.Internal.Data (Constr (..), Data (..), Field (..), Name (..), Type (..), fieldName, toDataTypes)
+import TreeSitter.GenerateAst.Internal.Data (Constr (..), Data (..), Field (..), Name (..), Type (..), fieldName, toDataTypes, unName)
 import TreeSitter.GenerateAst.Internal.Grammar (Grammar (..), RuleName)
 
 {- Note [One AstCache per syntax tree]

--- a/hs-tree-sitter-generate-ast/app/TreeSitter/GenerateAst/Internal/Data.hs
+++ b/hs-tree-sitter-generate-ast/app/TreeSitter/GenerateAst/Internal/Data.hs
@@ -9,6 +9,7 @@
 
 module TreeSitter.GenerateAst.Internal.Data (
   Name (..),
+  unName,
   Type (..),
   Constr (..),
   Data (..),
@@ -32,8 +33,15 @@ import Data.Vector (Vector)
 import Data.Vector qualified as V
 import TreeSitter.GenerateAst.Internal.Grammar (Grammar (..), Rule (..), RuleName)
 
-newtype Name = Name {unName :: Text}
+newtype Name = Name {getName :: Text}
   deriving newtype (Eq, Ord, Show, IsString)
+
+-- | If we have rules named: "rule" and "_rule" it will produce a
+-- conflict
+unName :: Name -> Text
+unName (Name n) = case Text.head n of
+  '_'        -> "hidden" <> n
+  _otherwise -> n
 
 data Type
   = Node Name


### PR DESCRIPTION
If the input grammar has hidden rule named the same as some other one, that is `_rule` and `rule`, ast generation will produce duplicate identifiers.